### PR TITLE
Terraform to create a S3 bucket with versioning and upload files

### DIFF
--- a/examples/terraform_aws_qxf2_s3_bucket/main.tf
+++ b/examples/terraform_aws_qxf2_s3_bucket/main.tf
@@ -16,8 +16,8 @@ resource "aws_s3_bucket_versioning" "versioning_test_bucket" {
 
 # Add files/objects into the bucket
 resource "aws_s3_object" "objects" {
-  for_each = fileset("path-to-objects-directory/", "*")
+  for_each = fileset("${var.OBJECTS_PATH}", "*")
   bucket = aws_s3_bucket.bucket.id
   key    = each.value
-  source = "path-to-objects-directory/${each.value}"
+  source = "${var.OBJECTS_PATH}/${each.value}"
 }

--- a/examples/terraform_aws_qxf2_s3_bucket/main.tf
+++ b/examples/terraform_aws_qxf2_s3_bucket/main.tf
@@ -1,0 +1,23 @@
+# Create a s3 bucket
+resource "aws_s3_bucket" "bucket" {
+  bucket = "qxf2-terraform-test-bucket"
+  tags = {
+        Name = "test bucket"
+  }
+}
+
+# Enable versioning for the bucket
+resource "aws_s3_bucket_versioning" "versioning_test_bucket" {
+  bucket = aws_s3_bucket.bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Add files/objects into the bucket
+resource "aws_s3_object" "objects" {
+  for_each = fileset("path-to-objects-directory/", "*")
+  bucket = aws_s3_bucket.bucket.id
+  key    = each.value
+  source = "path-to-objects-directory/${each.value}"
+}

--- a/examples/terraform_aws_qxf2_s3_bucket/objects/sample.txt
+++ b/examples/terraform_aws_qxf2_s3_bucket/objects/sample.txt
@@ -1,0 +1,1 @@
+A sample text file to be uploaded to s3 bucket, created using terraform!

--- a/examples/terraform_aws_qxf2_s3_bucket/objects/test.json
+++ b/examples/terraform_aws_qxf2_s3_bucket/objects/test.json
@@ -1,0 +1,4 @@
+{
+    "name" : "test.json",
+    "description" : "test object to be loaded into the s3 bucket created using terraform"
+}

--- a/examples/terraform_aws_qxf2_s3_bucket/outputs.tf
+++ b/examples/terraform_aws_qxf2_s3_bucket/outputs.tf
@@ -1,0 +1,19 @@
+output "s3_bucket_id" {
+  description = "The name of the bucket."
+  value       = aws_s3_bucket.bucket.id
+}
+
+output "s3_bucket_region" {
+  description = "The AWS region this bucket resides in."
+  value       = aws_s3_bucket.bucket.region
+}
+
+output "s3_bucket_arn" {
+  description = "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname."
+  value       = aws_s3_bucket.bucket.arn
+}
+
+output "s3_bucket_policy"{
+   description ="The policy of the bucket, if the bucket is configured with a policy. If not, this will be an empty string."
+   value       = aws_s3_bucket.bucket.policy
+}

--- a/examples/terraform_aws_qxf2_s3_bucket/provider.tf
+++ b/examples/terraform_aws_qxf2_s3_bucket/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = var.AWS_REGION
+  access_key = var.AWS_ACCESS_KEY_ID
+  secret_key = var.AWS_SECRET_ACCESS_KEY
+}

--- a/examples/terraform_aws_qxf2_s3_bucket/provider.tf
+++ b/examples/terraform_aws_qxf2_s3_bucket/provider.tf
@@ -8,8 +8,4 @@ terraform {
 }
 
 # Configure the AWS Provider
-provider "aws" {
-  region = var.AWS_REGION
-  access_key = var.AWS_ACCESS_KEY_ID
-  secret_key = var.AWS_SECRET_ACCESS_KEY
-}
+provider "aws" {}

--- a/examples/terraform_aws_qxf2_s3_bucket/test/verify/README.md
+++ b/examples/terraform_aws_qxf2_s3_bucket/test/verify/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec profile.

--- a/examples/terraform_aws_qxf2_s3_bucket/test/verify/controls/test_s3_bucket.rb
+++ b/examples/terraform_aws_qxf2_s3_bucket/test/verify/controls/test_s3_bucket.rb
@@ -1,0 +1,22 @@
+title "Tests to verify the S3 bucket configuration, created using Terraform"
+
+# Read the Terraform JSON ouput into variables
+content = inspec.profile.file("terraform.json")
+params = JSON.parse(content)
+BUCKET_NAME = params['s3_bucket_id']['value']
+BUCKET_REGION = params['s3_bucket_region']['value']
+
+control "Verify-S3-bucket" do
+  impact 1.0
+  title "Tests to verify configuration of S3 bucket"
+  describe aws_s3_bucket(bucket_name: BUCKET_NAME) do
+    it { should exist }
+    its('region') { should eq BUCKET_REGION }
+  end
+  describe aws_s3_bucket_objects(bucket_name: BUCKET_NAME) do
+    it { should exist }
+    its('key_counts') { should include 2 }
+  end
+end
+
+

--- a/examples/terraform_aws_qxf2_s3_bucket/test/verify/files/terraform.json
+++ b/examples/terraform_aws_qxf2_s3_bucket/test/verify/files/terraform.json
@@ -1,0 +1,22 @@
+{
+  "s3_bucket_arn": {
+    "sensitive": false,
+    "type": "string",
+    "value": "arn:aws:s3:::qxf2-terraform-test-bucket"
+  },
+  "s3_bucket_id": {
+    "sensitive": false,
+    "type": "string",
+    "value": "qxf2-terraform-test-bucket"
+  },
+  "s3_bucket_policy": {
+    "sensitive": false,
+    "type": "string",
+    "value": ""
+  },
+  "s3_bucket_region": {
+    "sensitive": false,
+    "type": "string",
+    "value": "ap-south-1"
+  }
+}

--- a/examples/terraform_aws_qxf2_s3_bucket/test/verify/inspec.yml
+++ b/examples/terraform_aws_qxf2_s3_bucket/test/verify/inspec.yml
@@ -1,0 +1,13 @@
+name: verify
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  - platform: aws
+depends:
+  - name: inspec-aws
+    url: https://github.com/inspec/inspec-aws/archive/v1.83.60.tar.gz

--- a/examples/terraform_aws_qxf2_s3_bucket/variables.tf
+++ b/examples/terraform_aws_qxf2_s3_bucket/variables.tf
@@ -1,18 +1,5 @@
-
-variable "AWS_REGION" {
-  description = "AWS region"
+variable "OBJECTS_PATH" {
+  description = "Path to the objects directory"
   type        = string
-  default     = "region-name"
-}
-
-variable "AWS_ACCESS_KEY_ID" {
-  description = "AWS access key"
-  type        = string
-  default     = "access-key-id"
-}
-
-variable "AWS_SECRET_ACCESS_KEY" {
-  description = "AWS secret access key"
-  type        = string
-  default     = "secret-access-key"
+  default     = "./objects/"
 }

--- a/examples/terraform_aws_qxf2_s3_bucket/variables.tf
+++ b/examples/terraform_aws_qxf2_s3_bucket/variables.tf
@@ -1,0 +1,18 @@
+
+variable "AWS_REGION" {
+  description = "AWS region"
+  type        = string
+  default     = "region-name"
+}
+
+variable "AWS_ACCESS_KEY_ID" {
+  description = "AWS access key"
+  type        = string
+  default     = "access-key-id"
+}
+
+variable "AWS_SECRET_ACCESS_KEY" {
+  description = "AWS secret access key"
+  type        = string
+  default     = "secret-access-key"
+}


### PR DESCRIPTION
A Terraform to create an AWS S3 bucket with versioning enabled and upload multiple files/objects into it.
- Had implemented, tested, and destroyed the resources created as part of this exercise. Will share the video recording of the same.

04/09/2023:
Latest changes include:
- Fetching AWS credentials have been updated to read from the environment
- Sample objects have been included to be uploaded to S3
- An Inspec test has been written to verify the S3 bucket and object count
![s3_bucket_tests](https://github.com/nelabhotlaR/terraform_exercises_20230808/assets/52440868/ac50cb65-35d1-496c-bd15-8750e448bbc5)
