### PR TITLE
Implemented solution for the terraform docker cars-api exercise

### DIFF
--- a/examples/terraform_aws_qxf2_carsapi_docker_image/main.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/main.tf
@@ -79,6 +79,6 @@ resource "aws_instance" "app_server" {
 
               cd cars-api/
               sudo docker build -t cars-api .
-              sudo docker run -p 5000:5000 cars-api
+              sudo docker run --name cars-api -p 5000:5000 cars-api
               EOF
 }

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/main.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/main.tf
@@ -1,20 +1,6 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.16"
-    }
-  }
-
-  required_version = ">= 1.2.0"
-}
-
-provider "aws" {
-  region  = "ap-south-1"
-}
-
+# Create a Security Group for EC2 instance
 resource "aws_security_group" "terraform_sg" {
-  name        = "allow_tls"
+  name        = "tls_cars"
   description = "Allow TLS inbound traffic"
 
   ingress {
@@ -66,10 +52,16 @@ resource "aws_security_group" "terraform_sg" {
   }
 }
 
+resource "aws_key_pair" "ssh-key" {
+  key_name   = "ssh-key"
+  public_key = file(var.ssh_public_key)
+}
+
+# Create an EC2 instance 
 resource "aws_instance" "app_server" {
   ami           = "ami-0f5ee92e2d63afc18"
   instance_type = "t2.micro"
-  
+  key_name = aws_key_pair.ssh-key.key_name
   vpc_security_group_ids = [aws_security_group.terraform_sg.id]
 
   tags = {
@@ -90,5 +82,3 @@ resource "aws_instance" "app_server" {
               sudo docker run -p 5000:5000 cars-api
               EOF
 }
-
-

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/main.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/main.tf
@@ -59,9 +59,9 @@ resource "aws_key_pair" "ssh-key" {
 
 # Create an EC2 instance 
 resource "aws_instance" "app_server" {
-  ami           = "ami-0f5ee92e2d63afc18"
-  instance_type = "t2.micro"
-  key_name = aws_key_pair.ssh-key.key_name
+  ami                    = "ami-053b0d53c279acc90"
+  instance_type          = "t2.micro"
+  key_name               = aws_key_pair.ssh-key.key_name
   vpc_security_group_ids = [aws_security_group.terraform_sg.id]
 
   tags = {

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/main.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/main.tf
@@ -1,0 +1,94 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region  = "ap-south-1"
+}
+
+resource "aws_security_group" "terraform_sg" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+
+  ingress {
+    description      = "HTTPS"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "HTTP"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "SSH"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Docker"
+    from_port        = 5000
+    to_port          = 5000
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name = "terraform_sg"
+  }
+}
+
+resource "aws_instance" "app_server" {
+  ami           = "ami-0f5ee92e2d63afc18"
+  instance_type = "t2.micro"
+  
+  vpc_security_group_ids = [aws_security_group.terraform_sg.id]
+
+  tags = {
+    Name = "terraform-carsapi"
+  }
+
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo apt update -y
+              sudo apt install docker.io -y
+              sudo service docker start
+              sudo usermod -a -G docker ubuntu
+
+              git clone https://github.com/qxf2/cars-api.git
+
+              cd cars-api/
+              sudo docker build -t cars-api .
+              sudo docker run -p 5000:5000 cars-api
+              EOF
+}
+
+

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/outputs.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/outputs.tf
@@ -1,0 +1,14 @@
+output "public_ip" {
+    description = "The Public IP of the EC2 instance"
+    value = aws_instance.app_server.public_ip
+}
+
+output "public_dns" {
+    description = "The public DNS of the EC2 instance"
+    value = aws_instance.app_server.public_dns
+}
+
+output "instance_id" {
+    description = "The Instance ID of the EC2 instance"
+    value = aws_instance.app_server.id
+}

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/outputs.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/outputs.tf
@@ -1,14 +1,14 @@
 output "public_ip" {
-    description = "The Public IP of the EC2 instance"
-    value = aws_instance.app_server.public_ip
+  description = "The Public IP of the EC2 instance"
+  value       = aws_instance.app_server.public_ip
 }
 
 output "public_dns" {
-    description = "The public DNS of the EC2 instance"
-    value = aws_instance.app_server.public_dns
+  description = "The public DNS of the EC2 instance"
+  value       = aws_instance.app_server.public_dns
 }
 
 output "instance_id" {
-    description = "The Instance ID of the EC2 instance"
-    value = aws_instance.app_server.id
+  description = "The Instance ID of the EC2 instance"
+  value       = aws_instance.app_server.id
 }

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/provider.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.profile_name
+}

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/test/verify/controls/test_ec2_configuration.rb
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/test/verify/controls/test_ec2_configuration.rb
@@ -1,0 +1,112 @@
+title "Test to verify if the AWS EC2 instance is configured properly"
+
+# Load the JSON data from terraform.json
+content = inspec.profile.file("terraform.json")
+params = JSON.parse(content)
+
+instance_id = params['instance_id']['value']
+public_dns = params['public_dns']['value']
+public_ip = params['public_ip']['value']
+
+control 'ec2_instance_configuration' do
+  impact 0.7
+  title 'EC2 Instance Configuration Test'
+  desc 'Ensure the EC2 instance is properly configured'
+
+  describe aws_ec2_instance(instance_id) do
+    it { should be_running }
+    its('public_dns_name') { should eq public_dns }
+    its('public_ip_address') { should eq public_ip }
+    its('image_id') { should eq 'ami-0f5ee92e2d63afc18' }
+  end
+
+  describe aws_ec2_instance(instance_id) do
+    its('tags_hash') { should include('Name' => 'terraform-carsapi') }
+  end
+end
+
+control 'ec2_security_group' do
+  impact 0.7
+  title 'EC2 Instance Security Group Test'
+  desc 'Ensure the Security Group is properly created and configured'
+
+  describe aws_security_group(group_name: 'tls_cars') do
+    it { should exist }
+    its('group_id') { should_not eq '' }
+    its('vpc_id') { should_not eq '' }
+  end
+
+  describe aws_security_group(group_name: 'tls_cars') do
+    its('inbound_rules_count') { should cmp 8 }
+    it { should allow_in(port: 22, protocol: 'tcp', ipv4_range: '0.0.0.0/0', ipv6_range: '::/0') }
+    it { should allow_in(port: 5000, protocol: 'tcp', ipv4_range: '0.0.0.0/0', ipv6_range: '::/0') }
+    it { should allow_in(port: 443, protocol: 'tcp', ipv4_range: '0.0.0.0/0', ipv6_range: '::/0') }
+    it { should allow_in(port: 80, protocol: 'tcp', ipv4_range: '0.0.0.0/0', ipv6_range: '::/0') }
+  end
+
+  describe aws_security_group(group_name: 'tls_cars') do
+    it { should allow_out(port: 0, protocol: '-1', ipv4_range: '0.0.0.0/0', ipv6_range: '::/0') }
+  end
+end
+  
+control 'ec2_docker_check' do
+  impact 0.7
+  title 'EC2 Docker Test'
+  desc 'Ensure Docker is properly installed and configured on EC2 instance'
+  describe service('docker') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe docker.version do
+    its('Server.Version') { should cmp >= '20.10'}
+    its('Client.Version') { should cmp >= '20.10'}
+  end
+end
+  
+control 'ec2_docker_image_check' do
+  impact 0.7
+  title 'EC2 Docker Image Test'
+  desc 'Ensure Docker Image is properly created and configured'
+  describe docker_image('cars-api') do
+    it { should exist }
+    its('id') { should_not eq '' }
+  end
+
+  describe docker.images do
+    its('ids') { should_not eq '' }
+    its('repositories') { should include 'cars-api' }
+    its('tags') { should include 'latest' }
+  end
+end
+
+control 'ec2_docker_container_check' do
+  impact 0.7
+  title 'EC2 Docker Container Test'
+  desc 'Ensure Docker Container is up and running'
+  describe docker.containers do 
+    its('images') { should include 'cars-api' }
+  end
+ 
+  describe docker_container(name: 'cars-api') do
+    it { should exist }
+    it { should be_running }
+    its('id') { should_not eq '' }
+    its('image') { should eq 'cars-api' }
+    its('ports') { should include '0.0.0.0:5000->5000/tcp' }
+    its('command') { should eq 'python cars_app.py' }
+  end
+end
+
+control 'ec2_cars_app_check' do
+  impact 0.7
+  title 'EC2 Cars App Test'
+  desc 'Ensure the Cars API app is up and running'
+  describe http('http://localhost:5000/cars', 
+           auth: {user:'qxf2', pass: 'qxf2'},
+           method: 'GET') do
+    its('status') { should cmp 200 }
+    its('body') { should include '"successful":true' }
+  end
+end

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/test/verify/inspec.yml
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/test/verify/inspec.yml
@@ -1,0 +1,14 @@
+name: Test AWS EC2 instance with Docker
+title: InSpec Profile
+maintainer: Sravanti Tatiraju
+copyright: Sravanti Tatiraju
+copyright_email: sravanti.tatiraju@qxf2.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  - platform: aws
+  - platform-name: ubuntu
+depends:
+  - name: inspec-aws
+    url: https://github.com/inspec/inspec-aws/archive/v1.83.60.tar.gz

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/variables.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/variables.tf
@@ -1,17 +1,17 @@
 variable "aws_region" {
   description = "AWS region where the EC2 instance should be created"
   type        = string
-  default     = "ap-south-1"
+  default     = "us-east-1"
 }
 
 variable "profile_name" {
-  type = string
+  type        = string
   description = "The name of the AWS profile to use"
-  default = "default"
+  default     = "personal"
 }
 
 variable "ssh_public_key" {
   type        = string
   description = "The path of the SSH public key file"
-  default = "~/.ssh/id_rsa.pub"
+  default     = "~/.ssh/id_rsa.pub"
 }

--- a/examples/terraform_aws_qxf2_carsapi_docker_image/variables.tf
+++ b/examples/terraform_aws_qxf2_carsapi_docker_image/variables.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "AWS region where the EC2 instance should be created"
+  type        = string
+  default     = "ap-south-1"
+}
+
+variable "profile_name" {
+  type = string
+  description = "The name of the AWS profile to use"
+  default = "default"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "The path of the SSH public key file"
+  default = "~/.ssh/id_rsa.pub"
+}


### PR DESCRIPTION
Have added Chef Inspec tests:

Run the following command to create terraform.json:
terraform output –json > test/verify/files/terraform.json

Run the following command to execute the tests:
 inspec exec test/verify -t ssh://ubuntu@<ip_address> -i <path_of_pem_key>


Have added tests covering all the ec2 instance configuration, security group, docker and cars API app verification
```
Profile:   Amazon Web Services Resource Pack (inspec-aws)
Version:   1.83.60
Target:    ssh://ubuntu@43.205.116.226:22
Target ID: d692e0ef-952d-5d33-a793-b0fb0503c118

     No tests executed.

Profile Summary: 6 successful controls, 0 control failures, 0 controls skipped
Test Summary: 33 successful, 0 failures, 0 skipped
```


![inspec_tests_sh](https://github.com/nelabhotlaR/terraform_exercises_20230808/assets/62924721/cbcb6301-da9c-4b58-91a6-bd56d8b366c9)


This PR is implementation solution for the following assigned exercise:
Using Terraform, provision an AWS EC2 instance along with configuring the required security group and network components. Subsequently, install Docker on the EC2 instance
Building the Docker image cars-api: https://github.com/qxf2/cars-api.git
Run the Docker container. Launch the app hosted in Docker container.
Output Public IP, Public DNS, Instance ID

Have created the following files:
main.tf - Creates an ec2 instance in ap-south-1 region, creates a security group with ports 443, 5000, 80 and 22. Assigns the security group to the EC2 instance. 
Installs docker, clones the repo, runs the container with the cars-api image.
outputs.tf - outputs Public IP, Public DNS, Instance ID

For running the above:
Created an IAM user. Exported the credentials AWS_ACCESS_KEY and AWS_SECRET_ACCESS_KEY.

Tested by checking the following:
Console UI - checked whether the EC2 instance has been created. Logged in using EC2 console.
In the machine, checked whether docker is installed, the container has launched and the app is running

```
ubuntu@ip-172-31-38-114:~$ sudo docker ps
CONTAINER ID   IMAGE      COMMAND                CREATED          STATUS          PORTS                                       NAMES
88a1ef5cc9dd   cars-api   "python cars_app.py"   58 seconds ago   Up 57 seconds   0.0.0.0:5000->5000/tcp, :::5000->5000/tcp   pedantic_panini
ubuntu@ip-172-31-38-114:~$ sudo docker logs 88a1ef5cc9dd
 * Serving Flask app 'cars_app'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5000
 * Running on http://172.17.0.2:5000
Press CTRL+C to quit
ubuntu@ip-172-31-38-114:~$ 
```

Verified the app is running by using:
http://13.127.123.49:5000/

Terminated the EC2 instance after checking.



![terraform-cars-api](https://github.com/nelabhotlaR/terraform_exercises_20230808/assets/62924721/48a9b5de-71fe-4f17-9590-fe734f199103)

![terraform-cars-api_running](https://github.com/nelabhotlaR/terraform_exercises_20230808/assets/62924721/40e28156-fc3d-471a-a65f-01da25bde49d)
