### PR TITLE
Terraform to create an ec2 instance and deployment of flask ses form …

### DIFF
--- a/examples/terraform_aws_qxf2_flask_SES_form/main.tf
+++ b/examples/terraform_aws_qxf2_flask_SES_form/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+}
+
+resource "aws_instance" "app_server" {
+  ami           = "ami-011e48799a29115e9"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "FlaskSESFormServerInstance"
+  }
+}

--- a/examples/terraform_aws_qxf2_flask_SES_form/outputs.tf
+++ b/examples/terraform_aws_qxf2_flask_SES_form/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.app_server.id
+}
+
+output "instance_public_ip" {
+  description = "Public IP address of the EC2 instance"
+  value       = aws_instance.app_server.public_ip
+}


### PR DESCRIPTION
This PR creates an ec2 instance and deploys the flask ses form. It also outputs public IP and instance id.

terraform init..

<img width="655" alt="init" src="https://github.com/nelabhotlaR/terraform_exercises_20230808/assets/97028279/a8830f1c-66eb-4ff2-866c-34bbc4a9b483">

terraform apply..

<img width="896" alt="apply" src="https://github.com/nelabhotlaR/terraform_exercises_20230808/assets/97028279/d4a8d616-9f80-4554-8e06-17254bb060ac">

terraform output..

<img width="548" alt="output" src="https://github.com/nelabhotlaR/terraform_exercises_20230808/assets/97028279/e8f764c7-c767-4561-84e0-6b0571af4d3c">





