### PR TITLE
Deploy Practice testing AIML application

### DIFF
--- a/.github/workflows/practicse_aiml.yml
+++ b/.github/workflows/practicse_aiml.yml
@@ -1,0 +1,61 @@
+name: 'practicse aiml Terraform'
+
+on: [push, pull_request]
+ 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    environment: development
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Create SSH Directory
+      run: mkdir -p ~/.ssh
+
+    - name: setup the public key
+      run:  echo "${{ secrets.PUBLIC_KEY_NAME}}" > ~/.ssh/terraform.pub && chmod 600 ~/.ssh/terraform.pub
+
+    - name: Configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: arn:aws:iam::120666943157:role/github_workflow_terraform
+        aws-region: us-east-1
+    
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.5.6
+    
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with: 
+          filters: |
+            src:
+              - 'examples/terraform_aws_qxf2_practice_aiml_app/**'
+              - '.github/workflows/practicse_aiml'
+
+    - name: Terraform Init
+      if: steps.changes.outputs.src=='true'
+      run: cd examples/terraform_aws_qxf2_practice_aiml_app && terraform init
+
+    - name: Terraform Validate
+      run: cd examples/terraform_aws_qxf2_practice_aiml_app && terraform validate -no-color
+
+    - name: Terraform Plan
+      run: cd examples/terraform_aws_qxf2_practice_aiml_app && terraform plan -input=false
+
+      # On push to "main", deploy the Terraform infrastructure
+    - name: Terraform Apply
+      if: github.event_name == 'push'
+      run: cd examples/terraform_aws_qxf2_practice_aiml_app && terraform apply -auto-approve -input=false

--- a/examples/terraform_aws_qxf2_practice_aiml_app/deploy_aiml.tf
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/deploy_aiml.tf
@@ -1,0 +1,103 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_security_group" "aiml_security_group" {
+  name_prefix = "aiml-security-group-"
+  
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "example_instance" {
+  ami           = "ami-053b0d53c279acc90"
+  instance_type = "t3.micro"
+  key_name      = "temporary_key"
+  security_groups = [aws_security_group.aiml_security_group.name]
+  user_data = <<-EOF
+              #!/bin/bash
+              mkdir /home/ubuntu/code
+              cd /home/ubuntu/code
+              git clone https://github.com/qxf2/practice-testing-ai-ml
+              sudo chmod 777 practice-testing-ai-ml
+              cd practice-testing-ai-ml
+              sudo apt-get -y update
+              sudo apt-get -y install python3-pip
+              yes|sudo apt-get -y install python3-virtualenv
+              virtualenv venv
+              source venv/bin/activate
+              export  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+              pip install -r requirements.txt
+              pip install uwsgi
+
+              cat << EOF_SERVICE > /etc/systemd/system/aiml.service
+              [Unit]
+              Description=UWSGI instance for the practice-testing-ai-ml project
+              After=network.target
+              StartLimitIntervalSec=0
+
+              [Service]
+              Restart=always
+              RestartSec=1
+              User=ubuntu
+              Group=www-data
+              WorkingDirectory=/home/ubuntu/code/practice-testing-ai-ml
+              Environment="PATH=/home/ubuntu/code/practice-testing-ai-ml/venv/bin"
+              ExecStart=/home/ubuntu/code/practice-testing-ai-ml/venv/bin/uwsgi --ini aiml.ini
+
+              [Install]
+              WantedBy=multi-user.target
+              EOF_SERVICE
+              sudo chmod 777 /home/ubuntu
+              systemctl enable aiml.service
+              systemctl start aiml.service
+              sudo apt-get -y install nginx
+
+              # Configure NGINX to serve the uWSGI app
+              cat << EOF_NGINX > /etc/nginx/sites-available/aiml
+              server {
+                  listen 80;
+                  server_name _;
+
+                  location / {
+                      include uwsgi_params;
+                      uwsgi_pass unix:///home/ubuntu/code/practice-testing-ai-ml/aiml.sock;
+                  }
+              }
+              EOF_NGINX
+
+              sudo ln -s /etc/nginx/sites-available/aiml /etc/nginx/sites-enabled
+              sudo rm /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+              sudo nginx -t  # Check NGINX configuration
+              sudo systemctl reload nginx  # Restart NGINX
+              EOF
+              
+  tags = {
+    Name = "PracticeTestingAIML"
+  }
+}

--- a/examples/terraform_aws_qxf2_practice_aiml_app/deploy_aiml.tf
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/deploy_aiml.tf
@@ -34,7 +34,7 @@ resource "aws_security_group" "aiml_security_group" {
   }
 }
 
-resource "aws_instance" "example_instance" {
+resource "aws_instance" "aiml_instance" {
   ami           = "ami-053b0d53c279acc90"
   instance_type = "t3.micro"
   key_name      = "temporary_key"

--- a/examples/terraform_aws_qxf2_practice_aiml_app/deploy_aiml.tf
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/deploy_aiml.tf
@@ -37,7 +37,7 @@ resource "aws_security_group" "aiml_security_group" {
 resource "aws_instance" "aiml_instance" {
   ami           = "ami-053b0d53c279acc90"
   instance_type = "t3.micro"
-  key_name      = "temporary_key"
+  key_name      = "${aws_key_pair.aiml_key.id}"
   security_groups = [aws_security_group.aiml_security_group.name]
   user_data = <<-EOF
               #!/bin/bash
@@ -100,4 +100,9 @@ resource "aws_instance" "aiml_instance" {
   tags = {
     Name = "PracticeTestingAIML"
   }
+}
+
+resource "aws_key_pair" "aiml_key" {
+  key_name = "aimlkey"
+  public_key = file(var.public_key_path)
 }

--- a/examples/terraform_aws_qxf2_practice_aiml_app/output.tf
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/output.tf
@@ -1,0 +1,7 @@
+output "instance_public_ip" {
+  value = aws_instance.aiml_instance.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.aiml_instance.id
+}

--- a/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/README.md
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec profile.

--- a/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/controls/test_app_directory.rb
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/controls/test_app_directory.rb
@@ -1,0 +1,4 @@
+describe file('/home/ubuntu/code/practice-testing-ai-ml') do
+  it { should exist }
+  it { should be_directory }
+end

--- a/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/controls/test_instance_exists.rb
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/controls/test_instance_exists.rb
@@ -1,0 +1,7 @@
+content = inspec.profile.file("terraform_output.json")
+params = JSON.parse(content)
+instance_id = params["instance_id"]["value"]
+
+describe aws_ec2_instance(instance_id) do
+  it { should exist }
+end

--- a/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/controls/test_web_app.rb
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/controls/test_web_app.rb
@@ -1,0 +1,7 @@
+content = inspec.profile.file("terraform_output.json")
+params = JSON.parse(content)
+instance_ip = params["instance_public_ip"]["value"]
+
+describe http("http://#{instance_ip}") do
+  its('status') { should cmp 200 }
+end

--- a/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/files/terraform_output.json
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/files/terraform_output.json
@@ -1,0 +1,12 @@
+{
+  "instance_id": {
+    "sensitive": false,
+    "type": "string",
+    "value": "i-0cc17a902a7ab9d78"
+  },
+  "instance_public_ip": {
+    "sensitive": false,
+    "type": "string",
+    "value": "54.210.196.49"
+  }
+}

--- a/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/inspec.lock
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/inspec.lock
@@ -1,0 +1,8 @@
+---
+lockfile_version: 1
+depends:
+- name: inspec-aws
+  resolved_source:
+    url: https://github.com/inspec/inspec-aws/archive/v1.83.60.tar.gz
+    sha256: 234ed85d80926ae40531e5168b820c875a35fd20a07a375d6728797b68f7e6d1
+  version_constraints: []

--- a/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/inspec.yml
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/test/verify/inspec.yml
@@ -1,0 +1,14 @@
+name: verify
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  - platform: aws
+  - platform-name: ubuntu
+depends:
+  - name: inspec-aws
+    url: https://github.com/inspec/inspec-aws/archive/v1.83.60.tar.gz

--- a/examples/terraform_aws_qxf2_practice_aiml_app/variables.tf
+++ b/examples/terraform_aws_qxf2_practice_aiml_app/variables.tf
@@ -1,0 +1,5 @@
+variable "public_key_path" {
+  type        = string
+  description = "Path to the public key file"
+  default = "~/.ssh/terraform.pub"
+}


### PR DESCRIPTION
Added terraform script to create EC2 instance, using Ubuntu 22 AMI, in us-east-1 region with Practice testing AIML app deployed in it.
To run this. 
1. First you can modify the key name in the script to any key that you have created in your AWS account
2. Then run `terraform init`
3. Then `terraform apply`
4. It would pick up the credentials from the `credentials file` in your `.aws` directory
5. Once the instance is deployed,  get the IP of the instance and try to visit it in your web browser. You should see the AIML application

Edit:
Also added chef inspec tests 